### PR TITLE
デプロイ後の修正

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -29,7 +29,7 @@ class PrototypesController < ApplicationController
 
   def edit
     @prototype = Prototype.find(params[:id])
-    unless user_signed_in?
+    unless @prototype.user_id == current_user.id
       redirect_to action: :index
     end
   end


### PR DESCRIPTION
what
ユーザーのアクセス制限の修正

why
他のユーザーが編集画面に直接遷移出来ないようにするため。
